### PR TITLE
PollNewest() php 8.4.2

### DIFF
--- a/revolution_16/lib/mysqli.php
+++ b/revolution_16/lib/mysqli.php
@@ -12,6 +12,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 3 of the License.       */
 /************************************************************************/
+global $debugmysql; 
 define('NPDS_DEBUG', $debugmysql);
 $sql_nbREQ=0;
 

--- a/revolution_16/mainfile.php
+++ b/revolution_16/mainfile.php
@@ -2611,7 +2611,7 @@ function headlines($hid='', $block=true) {
    }
 }
 #autodoc PollNewest() : Bloc Sondage <br />=> syntaxe : <br />function#pollnewest<br />params#ID_du_sondage OU vide (dernier sondage créé)
-function PollNewest(int $id=null) : void {
+function PollNewest($id=0) {
    global $NPDS_Prefix;
    // snipe : multi-poll evolution
    if ($id!=0) {
@@ -2954,7 +2954,7 @@ function fab_groupes_bloc($user,$im) {
             $content .= '<div class="text-end small"><a href="user.php?op=askforgroupe&amp;askedgroup='.$groupe_id.'" title="'.translate('Envoi une demande aux administrateurs pour rejoindre ce groupe. Un message privé vous informera du résultat de votre demande.').'" data-bs-toggle="tooltip">'.translate('Rejoindre ce groupe').'</a></div>';
       $content .= '</li>';
    }
-   $content .= '
+   $content .= '//
          </ul>';
    if (autorisation(-127))
       $content.='

--- a/revolution_16/user.php
+++ b/revolution_16/user.php
@@ -1045,10 +1045,10 @@ function saveuser($uid, $name, $uname, $email, $femail, $url, $pass, $vpass, $bi
                $pass = crypt($pass, $hashpass);
 
                sql_query("UPDATE ".$NPDS_Prefix."users SET name='$name', email='$email', femail='".removeHack($femail)."', url='".removeHack($url)."', pass='$pass', hashkey='1', bio='".removeHack($bio)."', user_avatar='$user_avatar', user_occ='".removeHack($user_occ)."', user_from='".removeHack($user_from)."', user_intrest='".removeHack($user_intrest)."', user_sig='".removeHack($user_sig)."', user_viewemail='$a', send_email='$u', is_visible='$v', user_lnl='$w' WHERE uid='$uid'");
-               $result = sql_query("SELECT uid, uname, pass, storynum, umode, uorder, thold, noscore, ublockon, theme FROM ".$NPDS_Prefix."users WHERE uname='$uname' AND pass='$pass'");
+               $result = sql_query("SELECT uid, uname, pass, storynum, umode, uorder, thold, noscore, ublockon, theme, commentmax FROM ".$NPDS_Prefix."users WHERE uname='$uname' AND pass='$pass'");
                if (sql_num_rows($result)==1) {
                   $userinfo = sql_fetch_assoc($result);
-                  docookie($userinfo['uid'],$userinfo['uname'],$userinfo['pass'],$userinfo['storynum'],$userinfo['umode'],$userinfo['uorder'],$userinfo['thold'],$userinfo['noscore'],$userinfo['ublockon'],$userinfo['theme'],$userinfo['commentmax'], "",$skin);
+                  docookie($userinfo['uid'],$userinfo['uname'],$userinfo['pass'],$userinfo['storynum'],$userinfo['umode'],$userinfo['uorder'],$userinfo['thold'],$userinfo['noscore'],$userinfo['ublockon'],$userinfo['theme'],$userinfo['commentmax'], "");
                }
             } else
                  sql_query("UPDATE ".$NPDS_Prefix."users SET name='$name', email='$email', femail='".removeHack($femail)."', url='".removeHack($url)."', bio='".removeHack($bio)."', user_avatar='$user_avatar', user_occ='".removeHack($user_occ)."', user_from='".removeHack($user_from)."', user_intrest='".removeHack($user_intrest)."', user_sig='".removeHack($user_sig)."', user_viewemail='$a', send_email='$u', is_visible='$v', user_lnl='$w' WHERE uid='$uid'");


### PR DESCRIPTION
Deprecated: PollNewest(): Implicitly marking parameter $id as nullable is deprecated, the explicit nullable type must be used instead